### PR TITLE
Added check to see if n is an integer for cleaner output

### DIFF
--- a/jsonformatter.cpp
+++ b/jsonformatter.cpp
@@ -39,6 +39,7 @@ void printJson(const std::shared_ptr<JsonValue>& value,
         double n = value->getNumber();
         os << get_color(AnsiColor::NUMBER);
         if (std::isinf(n) || std::isnan(n)) os << "null";
+        else if (n==(long long)n) os << (long long)n;
         else os << std::fixed << std::setprecision(15) << n;
         os << get_reset();
         break;


### PR DESCRIPTION
fixes #13
I have added a line of code that checks if n is an integer. If it does happen to be an integer, the code keeps it that way, not adding floating point precision to it. this keeps the output relatively cleaner. My changes reside in the file jsonformatter.cpp on line 42.
<img width="550" height="212" alt="image" src="https://github.com/user-attachments/assets/46cf2365-3659-49b3-a5cf-339a104e9649" />