### PR TITLE
Added cstdint to jsonparser.cpp

### DIFF
--- a/jsonparser.cpp
+++ b/jsonparser.cpp
@@ -1,5 +1,6 @@
 #include "jsonparser.h"
 #include <cctype>
+#include <cstdint>
 #include <iomanip>
 #include <sstream>
 


### PR DESCRIPTION
jsonparser.cpp uses the type `uint32_t`, which is defined in cstdint, therefore it requires to include this library to compile.